### PR TITLE
Catch errors

### DIFF
--- a/sharedstreets/tests/data/http404-intersection.pbf
+++ b/sharedstreets/tests/data/http404-intersection.pbf
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>A53FC0534A33ABFB</RequestId><HostId>UXkAVgqi7HIyPJKvRhLgf2kPDuaCoS/xBh9BBjr/tG12wg52e6yM3ulQNPEDhZunc7M4qLndgks=</HostId></Error>

--- a/sharedstreets/tests/test_tile.py
+++ b/sharedstreets/tests/test_tile.py
@@ -25,6 +25,15 @@ class TestTile (unittest.TestCase):
         
         self.assertEqual(len(i), 0)
 
+    def test_iter_objects_http200_badresponse(self):
+        
+        with httmock.HTTMock(respond_locally):
+            intersections = tile.iter_objects('http://example.com/http404-intersection.pbf',
+                tile.data_classes['intersection'])
+            i = list(intersections)
+        
+        self.assertEqual(len(i), 0)
+
     def test_iter_objects_20180312_intersection(self):
         
         with httmock.HTTMock(respond_locally):

--- a/sharedstreets/tests/test_tile.py
+++ b/sharedstreets/tests/test_tile.py
@@ -32,7 +32,8 @@ class TestTile (unittest.TestCase):
                 tile.data_classes['intersection'])
             i = list(intersections)
         
-        self.assertEqual(len(i), 0)
+        # Behavior here is undefined, depending on Python/Protobuf version.
+        self.assertIn(len(i), (0, 1))
 
     def test_iter_objects_20180312_intersection(self):
         

--- a/sharedstreets/tests/test_tile.py
+++ b/sharedstreets/tests/test_tile.py
@@ -13,6 +13,15 @@ def respond_locally(url, request):
 
 class TestTile (unittest.TestCase):
 
+    def test_iter_objects_http404_intersection(self):
+        
+        with httmock.HTTMock(respond_locally):
+            intersections = tile.iter_objects('http://example.com/http404-intersection.pbf',
+                tile.data_classes['intersection'])
+            i = list(intersections)
+        
+        self.assertEqual(len(i), 0)
+
     def test_iter_objects_20180312_intersection(self):
         
         with httmock.HTTMock(respond_locally):

--- a/sharedstreets/tests/test_tile.py
+++ b/sharedstreets/tests/test_tile.py
@@ -14,9 +14,12 @@ def respond_locally(url, request):
 class TestTile (unittest.TestCase):
 
     def test_iter_objects_http404_intersection(self):
+    
+        def respond_404(url, request):
+            return httmock.response(404, b'<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>...</RequestId><HostId>...</HostId></Error>')
         
-        with httmock.HTTMock(respond_locally):
-            intersections = tile.iter_objects('http://example.com/http404-intersection.pbf',
+        with httmock.HTTMock(respond_404):
+            intersections = tile.iter_objects('http://example.com/404.pbf',
                 tile.data_classes['intersection'])
             i = list(intersections)
         

--- a/sharedstreets/tile.py
+++ b/sharedstreets/tile.py
@@ -1,5 +1,5 @@
 import argparse, itertools, sys, json, logging
-import ModestMaps.Core, ModestMaps.OpenStreetMap, uritemplate, requests
+import ModestMaps.Core, ModestMaps.OpenStreetMap, uritemplate, requests, google.protobuf.message
 from google.protobuf.internal.decoder import _DecodeVarint32
 from . import sharedstreets_pb2
 
@@ -39,9 +39,14 @@ def iter_objects(url, DataClass):
         message = response.content[position:position+message_length]
         position += message_length
 
-        object = DataClass()
-        object.ParseFromString(message)
-        yield object
+        try:
+            object = DataClass()
+            object.ParseFromString(message)
+        except google.protobuf.message.DecodeError:
+            # Empty tile? Shrug.
+            continue
+        else:
+            yield object
 
 def is_inside(southwest, northeast, geometry):
     ''' Return True if the geometry bbox is inside a location pair bbox.

--- a/sharedstreets/tile.py
+++ b/sharedstreets/tile.py
@@ -33,6 +33,10 @@ def iter_objects(url, DataClass):
     response, position = requests.get(url), 0
     logger.debug('Got {} bytes: {}'.format(len(response.content), repr(response.content[:32])))
 
+    if response.status_code not in range(200, 299):
+        logger.debug('Got HTTP {}'.format(response.status_code))
+        return
+
     while position < len(response.content):
         message_length, new_position = _DecodeVarint32(response.content, position)
         position = new_position


### PR DESCRIPTION
Missing tiles (HTTP 403, 404, etc.) can raise unexpected errors when parsed optimistically. 