### PR TITLE
Add the sharedstreets-ref-system repo as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sharedstreets-ref-system"]
+	path = sharedstreets-ref-system
+	url = https://github.com/sharedstreets/sharedstreets-ref-system

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ Current `.proto` files can can be found at
 [follow Python directions](https://developers.google.com/protocol-buffers/docs/reference/python-generated#invocation)
 to regenerate `sharedstreets/sharedstreets_pb2.py` if necessary:
 
-    protoc --proto_path=sharedstreets-ref-system/proto \
-        --python_out=sharedstreets-python/sharedstreets \
+    protoc -I=sharedstreets-ref-system/proto/ \
+        --python_out=sharedstreets/ \
         sharedstreets-ref-system/proto/sharedstreets.proto


### PR DESCRIPTION
This unifies the handling of protobufs with the
sharedstreets-pbf repo. Updated the readme instructions
to reflect the change. This would be a good Makefile
target in the future.

Tested this change by deleting sharedstreets/sharedstreets_pb2.py,
then regenerating it to ensure an empty diff.