### PR TITLE
[DataFrame] Clip to bounds

### DIFF
--- a/sharedstreets/dataframe/__init__.py
+++ b/sharedstreets/dataframe/__init__.py
@@ -42,11 +42,14 @@ def _make_frames(intersections, geometries):
         for item in geometries
         ]
 
-    kwargs = dict(drop=False, verify_integrity=True)
-    iframe = geopandas.GeoDataFrame.from_features(ifeatures).set_index('id', **kwargs)
-    gframe = geopandas.GeoDataFrame.from_features(gfeatures).set_index('id', **kwargs)
-    
-    return Frames(iframe, gframe)
+    def make_frame(features):
+        gdf = geopandas.GeoDataFrame.from_features(features)
+        return gdf.set_index('id', drop=False, verify_integrity=True)
+
+    intersectionsdf = make_frame(ifeatures)
+    geometriesdf = make_frame(gfeatures)
+
+    return Frames(intersectionsdf, geometriesdf)
 
 def get_bbox(minlon, minlat, maxlon, maxlat, data_url_template=None):
     ''' Get a single Frames instance of SharedStreets entities in an area.

--- a/sharedstreets/dataframe/__init__.py
+++ b/sharedstreets/dataframe/__init__.py
@@ -50,7 +50,7 @@ def _make_frames(intersections, geometries, bounds=None):
         return gdf.iloc[index]
 
     def make_frame(features):
-        gdf = geopandas.GeoDataFrame.from_features(features)
+        gdf = geopandas.GeoDataFrame.from_features(features, crs={'init': 'epsg:4326'})
         return gdf.set_index('id', drop=False, verify_integrity=True)
 
     intersectionsdf = clip_bbox(make_frame(ifeatures))

--- a/sharedstreets/tests/test_dataframe.py
+++ b/sharedstreets/tests/test_dataframe.py
@@ -13,11 +13,15 @@ mock_tile = mock.Mock()
 mock_tile.intersections = {
     'NNNN': Intersection('NNNN', 1, ['IN'], ['NI'], -0.000113, 0.000038),
     'dddd': Intersection('dddd', 4, ['NI'], ['IN'], 0.000231, -0.000032),
+    'OOOO': Intersection('OOOO', 5, ['LO'], ['OL'], -122.2589, 37.8116),
+    'land': Intersection('land', 8, ['OL'], ['LO'], -122.2341, 37.8068),
     }
 
 mock_tile.geometries = {
     'NlId': Geometry('NlId', 6, 'NNNN', 'dddd', 'NI', 'IN',
         [-0.000113, 0.000038, 0.000027, 0.000032, 0.000038, -0.000027, 0.000231, -0.000032]),
+    'Okld': Geometry('Okld', 6, 'OOOO', 'land', 'OL', 'LO',
+        [-122.2589, 37.8116, -122.2472, 37.8119, -122.2468, 37.8068, -122.2341, 37.8068]),
     }
 
 class TestDataframe (unittest.TestCase):
@@ -28,12 +32,12 @@ class TestDataframe (unittest.TestCase):
             get_tile.return_value = mock_tile
             frames = dataframe.get_tile(12, 2048, 2048)
         
-        self.assertEqual(set(frames.intersections.id), {'NNNN', 'dddd'})
-        self.assertEqual(set(frames.intersections.nodeId), {1, 4})
-        self.assertEqual(set(frames.geometries.id), {'NlId'})
-        self.assertEqual(set(frames.geometries.fromIntersectionId), {'NNNN'})
-        self.assertEqual(set(frames.geometries.toIntersectionId), {'dddd'})
-    
+        self.assertEqual(set(frames.intersections.id), {'NNNN', 'dddd', 'OOOO', 'land'})
+        self.assertEqual(set(frames.intersections.nodeId), {1, 4, 5, 8})
+        self.assertEqual(set(frames.geometries.id), {'NlId', 'Okld'})
+        self.assertEqual(set(frames.geometries.fromIntersectionId), {'NNNN', 'OOOO'})
+        self.assertEqual(set(frames.geometries.toIntersectionId), {'dddd', 'land'})
+
     def test_get_bbox(self):
         
         with mock.patch('sharedstreets.tile.get_tile') as get_tile:


### PR DESCRIPTION
The PR makes a small change to `get_bbox` to optionally filter rows by the given bounds. I found this more useful (and less surprising). @migurski I think this is where you were headed anyway, right?

Note: optional clipping preserves the `get_tile` behavior, which has implicit bounds.

<img width="589" alt="screenshot 2018-09-19 21 58 47" src="https://user-images.githubusercontent.com/331023/45796800-3f00e500-bc57-11e8-98c4-bc9f4c6b9eb3.png">

https://gist.github.com/invisiblefunnel/9acbd0bf942a5b607eb9beb1c8bc3070